### PR TITLE
Add network-wide crash recovery procedures/unfinalized head initialization for a single node setup

### DIFF
--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -172,9 +172,9 @@ func WithClockSynchronizer(gs *startup.ClockSynchronizer) Option {
 	}
 }
 
-func WithFinalizedHeadAtStartup() Option {
+func WithUnfinalizedHead() Option {
 	return func(s *Service) error {
-		s.cfg.StartFromFinalizedCheckpoint = true
+		s.cfg.UnfinalizedStartEnabled = true
 		return nil
 	}
 }

--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -172,9 +172,9 @@ func WithClockSynchronizer(gs *startup.ClockSynchronizer) Option {
 	}
 }
 
-func WithUnfinalizedHeadAtStartup() Option {
+func WithFinalizedHeadAtStartup() Option {
 	return func(s *Service) error {
-		s.cfg.LoadUnfinalizedBlocksAtStartup = true
+		s.cfg.StartFromFinalizedCheckpoint = true
 		return nil
 	}
 }

--- a/beacon-chain/blockchain/options.go
+++ b/beacon-chain/blockchain/options.go
@@ -172,9 +172,9 @@ func WithClockSynchronizer(gs *startup.ClockSynchronizer) Option {
 	}
 }
 
-func WithSyncComplete(c chan struct{}) Option {
+func WithUnfinalizedHeadAtStartup() Option {
 	return func(s *Service) error {
-		s.syncComplete = c
+		s.cfg.LoadUnfinalizedBlocksAtStartup = true
 		return nil
 	}
 }

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -681,6 +681,8 @@ func (s *Service) handleInvalidExecutionError(ctx context.Context, err error, bl
 // to unfinalized blocks coming from the db at startup. The operations consist of:
 //  1. Apply fork choice to the unfinalized block
 //  2. Save latest head info
+//
+// Requires a lock on forkchoice.
 func (s *Service) processUnfinalizedBlocksFromDB() error {
 	startTime := time.Now()
 

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -675,3 +675,91 @@ func (s *Service) handleInvalidExecutionError(ctx context.Context, err error, bl
 	}
 	return err
 }
+
+// processUnfinalizedBlocksFromDB is a function that defines the operations that are performed
+// to unfinalized blocks coming from the db at startup. The operations consist of:
+//  1. Apply fork choice to the unfinalized block
+//  2. Save latest head info
+func (s *Service) processUnfinalizedBlocksFromDB() error {
+	headBlkDB, err := s.cfg.BeaconDB.HeadBlock(s.ctx)
+	if err != nil {
+		return errors.Wrap(err, "could not get head block from db")
+	}
+
+	if startSlot, endSlot := s.head.block.Block().Slot(), headBlkDB.Block().Slot(); endSlot > startSlot {
+		unfinalizedBlks, err := s.loadBlocks(s.ctx, startSlot+1, endSlot)
+		if err != nil {
+			return errors.Wrap(err, "could not get unfinalized blocks from db")
+		}
+
+		s.cfg.ForkChoiceStore.Lock()
+		defer s.cfg.ForkChoiceStore.Unlock()
+
+		for _, blk := range unfinalizedBlks {
+			blkCopy, err := blk.Copy()
+			if err != nil {
+				return err
+			}
+
+			blkRoot, err := blkCopy.Block().HashTreeRoot()
+			if err != nil {
+				return errors.Wrap(err, "could not get unfinalized block root")
+			}
+
+			postState, err := s.cfg.StateGen.StateByRoot(s.ctx, blkRoot)
+			if err != nil {
+				return errors.Wrap(err, "could not get unfinalized block state")
+			}
+
+			if err := s.cfg.ForkChoiceStore.InsertNode(s.ctx, postState, blkRoot); err != nil {
+				return errors.Wrapf(err, "could not insert unfinalized block %d to fork choice store", blkCopy.Block().Slot())
+			}
+
+			if err := s.handleBlockAttestations(s.ctx, blkCopy.Block(), postState); err != nil {
+				return errors.Wrap(err, "could not handle block's attestations")
+			}
+
+			s.InsertSlashingsToForkChoiceStore(s.ctx, blkCopy.Block().Body().AttesterSlashings())
+
+			if err := s.cfg.ForkChoiceStore.SetOptimisticToValid(s.ctx, blkRoot); err != nil {
+				return errors.Wrap(err, "could not set optimistic block to valid")
+			}
+
+			headRoot, err := s.cfg.ForkChoiceStore.Head(s.ctx)
+			if err != nil {
+				log.WithError(err).Warn("Could not update head")
+			}
+
+			// new beacon chain head
+			if blkRoot == headRoot {
+				if err := s.saveHead(s.ctx, blkRoot, blkCopy, postState); err != nil {
+					return errors.Wrap(err, "could not notify forkchoice update")
+				}
+
+				if err := s.pruneAttsFromPool(blkCopy); err != nil {
+					log.WithError(err).Error("could not prune attestations from pool")
+				}
+
+				if slot := postState.Slot(); slots.IsEpochEnd(slot) {
+					if err := transition.UpdateNextSlotCache(s.ctx, blkRoot[:], postState); err != nil {
+						return errors.Wrap(err, "could not update next slot state cache")
+					}
+					if err := s.handleEpochBoundary(s.ctx, slot, postState, blkRoot[:]); err != nil {
+						return errors.Wrap(err, "could not handle epoch boundary")
+					}
+				} else {
+					go func() {
+						slotCtx, cancel := context.WithTimeout(context.Background(), slotDeadline)
+						defer cancel()
+						if err := transition.UpdateNextSlotCache(slotCtx, blkRoot[:], postState); err != nil {
+							log.WithError(err).Error("could not update next slot state cache")
+						}
+					}()
+				}
+			}
+
+		}
+	}
+
+	return nil
+}

--- a/beacon-chain/blockchain/process_block.go
+++ b/beacon-chain/blockchain/process_block.go
@@ -15,7 +15,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db/filters"
-	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db/iface"
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/state"
 	"github.com/prysmaticlabs/prysm/v4/config/features"
@@ -788,7 +787,7 @@ func (s *Service) processUnfinalizedBlocksFromDB() error {
 }
 
 // loadBlocks loads the blocks between start slot and end slot.
-func loadBlocks(ctx context.Context, beaconDB iface.HeadAccessDatabase, startSlot, endSlot primitives.Slot) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
+func loadBlocks(ctx context.Context, beaconDB db.NoHeadAccessDatabase, startSlot, endSlot primitives.Slot) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
 	// Nothing to load for invalid range.
 	if startSlot > endSlot {
 		return nil, fmt.Errorf("start slot %d > end slot %d", startSlot, endSlot)

--- a/beacon-chain/blockchain/process_block_test.go
+++ b/beacon-chain/blockchain/process_block_test.go
@@ -2260,22 +2260,6 @@ func TestService_ProcessUnfinalizedBlocksFromDB(t *testing.T) {
 				}
 			},
 		},
-		/*
-			{
-				name: "applies unfinalized block with state transition",
-				args: args{
-					block: genFullBlock(t, util.DefaultBlockGenConfig(), 2),
-				},
-				check: func(t *testing.T, s *Service) {
-					if hs := s.head.state.Slot(); hs != 2 {
-						t.Errorf("Unexpected state slot. Got %d but wanted %d", hs, 2)
-					}
-					if bs := s.head.block.Block().Slot(); bs != 2 {
-						t.Errorf("Unexpected head block slot. Got %d but wanted %d", bs, 2)
-					}
-				},
-			},
-		*/
 	}
 
 	wg := new(sync.WaitGroup)
@@ -2297,13 +2281,12 @@ func TestService_ProcessUnfinalizedBlocksFromDB(t *testing.T) {
 			require.NoError(t, s.saveGenesisData(ctx, genesisSt))
 
 			if tt.args.block != nil {
-				util.SaveBlock(t, ctx, beaconDB, tt.args.block)
-
-				root, err := tt.args.block.HashTreeRoot()
+				wsb := util.SaveBlock(t, ctx, beaconDB, tt.args.block)
+				root, err := wsb.Block().HashTreeRoot()
 				require.NoError(t, err)
 
 				ss := &ethpb.StateSummary{
-					Slot: tt.args.block.Block.Slot,
+					Slot: wsb.Block().Slot(),
 					Root: root[:],
 				}
 				require.NoError(t, beaconDB.SaveStateSummary(ctx, ss))

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -20,7 +20,6 @@ import (
 	coreTime "github.com/prysmaticlabs/prysm/v4/beacon-chain/core/time"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/core/transition"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db"
-	"github.com/prysmaticlabs/prysm/v4/beacon-chain/db/filters"
 	"github.com/prysmaticlabs/prysm/v4/beacon-chain/execution"
 	f "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice"
 	forkchoicetypes "github.com/prysmaticlabs/prysm/v4/beacon-chain/forkchoice/types"
@@ -37,7 +36,6 @@ import (
 	"github.com/prysmaticlabs/prysm/v4/config/params"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/blocks"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/interfaces"
-	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	"github.com/prysmaticlabs/prysm/v4/encoding/bytesutil"
 	ethpb "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
 	prysmTime "github.com/prysmaticlabs/prysm/v4/time"
@@ -211,25 +209,6 @@ func (s *Service) Status() error {
 		return fmt.Errorf("too many goroutines (%d)", runtime.NumGoroutine())
 	}
 	return nil
-}
-
-// loadBlocks loads the blocks between start slot and end slot.
-func (s *Service) loadBlocks(ctx context.Context, startSlot, endSlot primitives.Slot) ([]interfaces.ReadOnlySignedBeaconBlock, error) {
-	// Nothing to load for invalid range.
-	if startSlot > endSlot {
-		return nil, fmt.Errorf("start slot %d > end slot %d", startSlot, endSlot)
-	}
-	filter := filters.NewFilter().SetStartSlot(startSlot).SetEndSlot(endSlot)
-	blocks, blockRoots, err := s.cfg.BeaconDB.Blocks(ctx, filter)
-	if err != nil {
-		return nil, err
-	}
-	// The retrieved blocks and block roots have to be in the same length given same filter.
-	if len(blocks) != len(blockRoots) {
-		return nil, errors.New("length of blocks and roots don't match")
-	}
-
-	return blocks, nil
 }
 
 // StartFromSavedState initializes the blockchain using a previously saved finalized checkpoint.

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -69,27 +69,27 @@ type Service struct {
 
 // config options for the service.
 type config struct {
-	BeaconBlockBuf                 int
-	ChainStartFetcher              execution.ChainStartFetcher
-	BeaconDB                       db.HeadAccessDatabase
-	DepositCache                   cache.DepositCache
-	ProposerSlotIndexCache         *cache.ProposerPayloadIDsCache
-	AttPool                        attestations.Pool
-	ExitPool                       voluntaryexits.PoolManager
-	SlashingPool                   slashings.PoolManager
-	BLSToExecPool                  blstoexec.PoolManager
-	P2p                            p2p.Broadcaster
-	MaxRoutines                    int
-	StateNotifier                  statefeed.Notifier
-	ForkChoiceStore                f.ForkChoicer
-	AttService                     *attestations.Service
-	StateGen                       *stategen.State
-	SlasherAttestationsFeed        *event.Feed
-	WeakSubjectivityCheckpt        *ethpb.Checkpoint
-	BlockFetcher                   execution.POWBlockFetcher
-	FinalizedStateAtStartUp        state.BeaconState
-	LoadUnfinalizedBlocksAtStartup bool
-	ExecutionEngineCaller          execution.EngineCaller
+	BeaconBlockBuf               int
+	ChainStartFetcher            execution.ChainStartFetcher
+	BeaconDB                     db.HeadAccessDatabase
+	DepositCache                 cache.DepositCache
+	ProposerSlotIndexCache       *cache.ProposerPayloadIDsCache
+	AttPool                      attestations.Pool
+	ExitPool                     voluntaryexits.PoolManager
+	SlashingPool                 slashings.PoolManager
+	BLSToExecPool                blstoexec.PoolManager
+	P2p                          p2p.Broadcaster
+	MaxRoutines                  int
+	StateNotifier                statefeed.Notifier
+	ForkChoiceStore              f.ForkChoicer
+	AttService                   *attestations.Service
+	StateGen                     *stategen.State
+	SlasherAttestationsFeed      *event.Feed
+	WeakSubjectivityCheckpt      *ethpb.Checkpoint
+	BlockFetcher                 execution.POWBlockFetcher
+	FinalizedStateAtStartUp      state.BeaconState
+	StartFromFinalizedCheckpoint bool
+	ExecutionEngineCaller        execution.EngineCaller
 }
 
 var ErrMissingClockSetter = errors.New("blockchain Service initialized without a startup.ClockSetter")
@@ -296,7 +296,7 @@ func (s *Service) StartFromSavedState(saved state.BeaconState) error {
 		}
 	}
 
-	if s.cfg.LoadUnfinalizedBlocksAtStartup {
+	if !s.cfg.StartFromFinalizedCheckpoint {
 		if err := s.processUnfinalizedBlocksFromDB(); err != nil {
 			return errors.Wrap(err, "could not process unfinalized blocks from db")
 		}

--- a/beacon-chain/blockchain/service.go
+++ b/beacon-chain/blockchain/service.go
@@ -67,27 +67,27 @@ type Service struct {
 
 // config options for the service.
 type config struct {
-	BeaconBlockBuf               int
-	ChainStartFetcher            execution.ChainStartFetcher
-	BeaconDB                     db.HeadAccessDatabase
-	DepositCache                 cache.DepositCache
-	ProposerSlotIndexCache       *cache.ProposerPayloadIDsCache
-	AttPool                      attestations.Pool
-	ExitPool                     voluntaryexits.PoolManager
-	SlashingPool                 slashings.PoolManager
-	BLSToExecPool                blstoexec.PoolManager
-	P2p                          p2p.Broadcaster
-	MaxRoutines                  int
-	StateNotifier                statefeed.Notifier
-	ForkChoiceStore              f.ForkChoicer
-	AttService                   *attestations.Service
-	StateGen                     *stategen.State
-	SlasherAttestationsFeed      *event.Feed
-	WeakSubjectivityCheckpt      *ethpb.Checkpoint
-	BlockFetcher                 execution.POWBlockFetcher
-	FinalizedStateAtStartUp      state.BeaconState
-	StartFromFinalizedCheckpoint bool
-	ExecutionEngineCaller        execution.EngineCaller
+	BeaconBlockBuf          int
+	ChainStartFetcher       execution.ChainStartFetcher
+	BeaconDB                db.HeadAccessDatabase
+	DepositCache            cache.DepositCache
+	ProposerSlotIndexCache  *cache.ProposerPayloadIDsCache
+	AttPool                 attestations.Pool
+	ExitPool                voluntaryexits.PoolManager
+	SlashingPool            slashings.PoolManager
+	BLSToExecPool           blstoexec.PoolManager
+	P2p                     p2p.Broadcaster
+	MaxRoutines             int
+	StateNotifier           statefeed.Notifier
+	ForkChoiceStore         f.ForkChoicer
+	AttService              *attestations.Service
+	StateGen                *stategen.State
+	SlasherAttestationsFeed *event.Feed
+	WeakSubjectivityCheckpt *ethpb.Checkpoint
+	BlockFetcher            execution.POWBlockFetcher
+	FinalizedStateAtStartUp state.BeaconState
+	UnfinalizedStartEnabled bool
+	ExecutionEngineCaller   execution.EngineCaller
 }
 
 var ErrMissingClockSetter = errors.New("blockchain Service initialized without a startup.ClockSetter")
@@ -275,7 +275,7 @@ func (s *Service) StartFromSavedState(saved state.BeaconState) error {
 		}
 	}
 
-	if !s.cfg.StartFromFinalizedCheckpoint {
+	if s.cfg.UnfinalizedStartEnabled {
 		if err := s.processUnfinalizedBlocksFromDB(); err != nil {
 			return errors.Wrap(err, "could not process unfinalized blocks from db")
 		}

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -271,8 +271,8 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 	}
 
 	type args struct {
-		unfinalizedBlock             *ethpb.SignedBeaconBlock
-		startFromFinalizedCheckpoint bool
+		unfinalizedBlock        *ethpb.SignedBeaconBlock
+		unfinalizedStartEnabled bool
 	}
 
 	tests := []struct {
@@ -282,28 +282,25 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 	}{
 		{
 			name: "no unfinalized blocks + start from finalized checkpoint option enabled > finalized head",
-			args: args{
-				startFromFinalizedCheckpoint: true,
-			},
+			args: args{},
 		},
 		{
 			name: "db has unfinalized blocks + start from finalized checkpoint option enabled > finalized head",
 			args: args{
-				startFromFinalizedCheckpoint: true,
-				unfinalizedBlock:             genFullBlock(t, util.DefaultBlockGenConfig(), 1),
+				unfinalizedBlock: genFullBlock(t, util.DefaultBlockGenConfig(), 1),
 			},
 		},
 		{
 			name: "no unfinalized blocks + start from unfinalized head (default) > finalized head",
 			args: args{
-				startFromFinalizedCheckpoint: false,
+				unfinalizedStartEnabled: true,
 			},
 		},
 		{
 			name: "db has unfinalized blocks + start from unfinalized head (default) > unfinalized head",
 			args: args{
-				startFromFinalizedCheckpoint: false,
-				unfinalizedBlock:             genFullBlock(t, util.DefaultBlockGenConfig(), 1),
+				unfinalizedStartEnabled: true,
+				unfinalizedBlock:        genFullBlock(t, util.DefaultBlockGenConfig(), 1),
 			},
 		},
 	}
@@ -321,8 +318,8 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 				WithFinalizedStateAtStartUp(genesisState),
 			}
 
-			if tt.args.startFromFinalizedCheckpoint {
-				opts = append(opts, WithFinalizedHeadAtStartup())
+			if tt.args.unfinalizedStartEnabled {
+				opts = append(opts, WithUnfinalizedStart())
 			}
 
 			svc, tr := minimalTestService(t, opts...)

--- a/beacon-chain/blockchain/service_test.go
+++ b/beacon-chain/blockchain/service_test.go
@@ -281,23 +281,23 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 		wantedErr string
 	}{
 		{
-			name: "no unfinalized blocks + start from finalized checkpoint option enabled > finalized head",
+			name: "no unfinalized blocks + start from finalized checkpoint (default) > finalized head",
 			args: args{},
 		},
 		{
-			name: "db has unfinalized blocks + start from finalized checkpoint option enabled > finalized head",
+			name: "db has unfinalized blocks + start from finalized checkpoint (default) > finalized head",
 			args: args{
 				unfinalizedBlock: genFullBlock(t, util.DefaultBlockGenConfig(), 1),
 			},
 		},
 		{
-			name: "no unfinalized blocks + start from unfinalized head (default) > finalized head",
+			name: "no unfinalized blocks + start from unfinalized head option enabled > finalized head",
 			args: args{
 				unfinalizedStartEnabled: true,
 			},
 		},
 		{
-			name: "db has unfinalized blocks + start from unfinalized head (default) > unfinalized head",
+			name: "db has unfinalized blocks + start from unfinalized head option enabled > unfinalized head",
 			args: args{
 				unfinalizedStartEnabled: true,
 				unfinalizedBlock:        genFullBlock(t, util.DefaultBlockGenConfig(), 1),
@@ -319,7 +319,7 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 			}
 
 			if tt.args.unfinalizedStartEnabled {
-				opts = append(opts, WithUnfinalizedStart())
+				opts = append(opts, WithUnfinalizedHead())
 			}
 
 			svc, tr := minimalTestService(t, opts...)
@@ -363,7 +363,7 @@ func TestChainService_InitializeChainInfo(t *testing.T) {
 					expectedRoot    []byte
 				)
 
-				if svc.cfg.StartFromFinalizedCheckpoint || tt.args.unfinalizedBlock == nil {
+				if !svc.cfg.UnfinalizedStartEnabled || tt.args.unfinalizedBlock == nil {
 					var err error
 					expectedHeadBlk, err = genBlock.Proto()
 					require.NoError(t, err)

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -638,8 +638,8 @@ func (b *BeaconNode) registerBlockchainService(fc forkchoice.ForkChoicer, gs *st
 		blockchain.WithClockSynchronizer(gs),
 	)
 
-	if features.Get().StartFromFinalizedCheckpoint {
-		opts = append(opts, blockchain.WithFinalizedHeadAtStartup())
+	if features.Get().EnableStartUnfinalized || features.Get().EnableCrashRecovery {
+		opts = append(opts, blockchain.WithUnfinalizedHead())
 	}
 
 	blockchainService, err := blockchain.NewService(b.ctx, opts...)
@@ -728,13 +728,14 @@ func (b *BeaconNode) registerInitialSyncService(complete chan struct{}) error {
 	}
 
 	is := initialsync.NewService(b.ctx, &initialsync.Config{
-		DB:                  b.db,
-		Chain:               chainService,
-		P2P:                 b.fetchP2P(),
-		StateNotifier:       b,
-		BlockNotifier:       b,
-		ClockWaiter:         b.clockWaiter,
-		InitialSyncComplete: complete,
+		DB:                   b.db,
+		Chain:                chainService,
+		P2P:                  b.fetchP2P(),
+		StateNotifier:        b,
+		BlockNotifier:        b,
+		ClockWaiter:          b.clockWaiter,
+		InitialSyncComplete:  complete,
+		CrashRecoveryEnabled: features.Get().EnableCrashRecovery,
 	})
 	return b.services.RegisterService(is)
 }

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -636,8 +636,11 @@ func (b *BeaconNode) registerBlockchainService(fc forkchoice.ForkChoicer, gs *st
 		blockchain.WithFinalizedStateAtStartUp(b.finalizedStateAtStartUp),
 		blockchain.WithProposerIdsCache(b.proposerIdsCache),
 		blockchain.WithClockSynchronizer(gs),
-		blockchain.WithSyncComplete(syncComplete),
 	)
+
+	if features.Get().LoadUnfinalizedBlocksAtStartup {
+		opts = append(opts, blockchain.WithUnfinalizedHeadAtStartup())
+	}
 
 	blockchainService, err := blockchain.NewService(b.ctx, opts...)
 	if err != nil {

--- a/beacon-chain/node/node.go
+++ b/beacon-chain/node/node.go
@@ -638,8 +638,8 @@ func (b *BeaconNode) registerBlockchainService(fc forkchoice.ForkChoicer, gs *st
 		blockchain.WithClockSynchronizer(gs),
 	)
 
-	if features.Get().LoadUnfinalizedBlocksAtStartup {
-		opts = append(opts, blockchain.WithUnfinalizedHeadAtStartup())
+	if features.Get().StartFromFinalizedCheckpoint {
+		opts = append(opts, blockchain.WithFinalizedHeadAtStartup())
 	}
 
 	blockchainService, err := blockchain.NewService(b.ctx, opts...)

--- a/beacon-chain/sync/initial-sync/round_robin.go
+++ b/beacon-chain/sync/initial-sync/round_robin.go
@@ -116,13 +116,17 @@ func (s *Service) syncToNonFinalizedEpoch(ctx context.Context, genesis time.Time
 	if err != nil {
 		return errors.Wrapf(err, "unable to initialize context version map using genesis validator root = %#x", vr)
 	}
+	highestExpectedSlot := slots.Since(genesis)
+	if s.cfg.CrashRecoveryEnabled {
+		highestExpectedSlot = 0
+	}
 	queue := newBlocksQueue(ctx, &blocksQueueConfig{
 		p2p:                 s.cfg.P2P,
 		db:                  s.cfg.DB,
 		chain:               s.cfg.Chain,
 		clock:               s.clock,
 		ctxMap:              ctxMap,
-		highestExpectedSlot: slots.Since(genesis),
+		highestExpectedSlot: highestExpectedSlot,
 		mode:                modeNonConstrained,
 	})
 	if err := queue.start(); err != nil {

--- a/beacon-chain/sync/initial-sync/service.go
+++ b/beacon-chain/sync/initial-sync/service.go
@@ -34,13 +34,14 @@ type blockchainService interface {
 
 // Config to set up the initial sync service.
 type Config struct {
-	P2P                 p2p.P2P
-	DB                  db.NoHeadAccessDatabase
-	Chain               blockchainService
-	StateNotifier       statefeed.Notifier
-	BlockNotifier       blockfeed.Notifier
-	ClockWaiter         startup.ClockWaiter
-	InitialSyncComplete chan struct{}
+	P2P                  p2p.P2P
+	DB                   db.NoHeadAccessDatabase
+	Chain                blockchainService
+	StateNotifier        statefeed.Notifier
+	BlockNotifier        blockfeed.Notifier
+	ClockWaiter          startup.ClockWaiter
+	InitialSyncComplete  chan struct{}
+	CrashRecoveryEnabled bool
 }
 
 // Service service.

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -61,6 +61,10 @@ type Flags struct {
 	SaveFullExecutionPayloads bool // Save full beacon blocks with execution payloads in the database.
 	EnableStartOptimistic     bool // EnableStartOptimistic treats every block as optimistic at startup.
 
+	EnableStartUnfinalized bool // EnableStartUnfinalized enables the unfinalized block processing at startup.
+
+	EnableCrashRecovery bool // EnableCrashRecovery enables the crash recovery procedures.
+
 	DisableResourceManager     bool // Disables running the node with libp2p's resource manager.
 	DisableStakinContractCheck bool // Disables check for deposit contract when proposing blocks
 
@@ -79,9 +83,6 @@ type Flags struct {
 
 	// AggregateIntervals specifies the time durations at which we aggregate attestations preparing for forkchoice.
 	AggregateIntervals [3]time.Duration
-
-	// StartFromFinalizedCheckpoint instructs the blockchain service to set the head to the finalized checkpoint during the beacon chain init.
-	StartFromFinalizedCheckpoint bool
 }
 
 var featureConfig *Flags
@@ -259,8 +260,13 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		cfg.EnableEIP4881 = true
 	}
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
-	if ctx.Bool(startFromFinalizedCheckpoint.Name) {
-		cfg.StartFromFinalizedCheckpoint = true
+	if ctx.Bool(enableStartupUnfinalized.Name) {
+		logEnabled(enableStartupUnfinalized)
+		cfg.EnableStartUnfinalized = true
+	}
+	if ctx.Bool(enableCrashRecovery.Name) {
+		logEnabled(enableCrashRecovery)
+		cfg.EnableCrashRecovery = true
 	}
 	Init(cfg)
 	return nil

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -79,6 +79,9 @@ type Flags struct {
 
 	// AggregateIntervals specifies the time durations at which we aggregate attestations preparing for forkchoice.
 	AggregateIntervals [3]time.Duration
+
+	// LoadUnfinalizedBlocksAtStartup specifies whether to take the the unfinalized blocks into consideration during the chain head initialization.
+	LoadUnfinalizedBlocksAtStartup bool
 }
 
 var featureConfig *Flags
@@ -256,6 +259,9 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		cfg.EnableEIP4881 = true
 	}
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
+	if ctx.Bool(loadUnfinalizedBlocksAtStartup.Name) {
+		cfg.LoadUnfinalizedBlocksAtStartup = true
+	}
 	Init(cfg)
 	return nil
 }

--- a/config/features/config.go
+++ b/config/features/config.go
@@ -80,8 +80,8 @@ type Flags struct {
 	// AggregateIntervals specifies the time durations at which we aggregate attestations preparing for forkchoice.
 	AggregateIntervals [3]time.Duration
 
-	// LoadUnfinalizedBlocksAtStartup specifies whether to take the the unfinalized blocks into consideration during the chain head initialization.
-	LoadUnfinalizedBlocksAtStartup bool
+	// StartFromFinalizedCheckpoint instructs the blockchain service to set the head to the finalized checkpoint during the beacon chain init.
+	StartFromFinalizedCheckpoint bool
 }
 
 var featureConfig *Flags
@@ -259,8 +259,8 @@ func ConfigureBeaconChain(ctx *cli.Context) error {
 		cfg.EnableEIP4881 = true
 	}
 	cfg.AggregateIntervals = [3]time.Duration{aggregateFirstInterval.Value, aggregateSecondInterval.Value, aggregateThirdInterval.Value}
-	if ctx.Bool(loadUnfinalizedBlocksAtStartup.Name) {
-		cfg.LoadUnfinalizedBlocksAtStartup = true
+	if ctx.Bool(startFromFinalizedCheckpoint.Name) {
+		cfg.StartFromFinalizedCheckpoint = true
 	}
 	Init(cfg)
 	return nil

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -169,9 +169,9 @@ var (
 		Usage: "Disables parallel aggregation of attestations",
 	}
 
-	loadUnfinalizedBlocksAtStartup = &cli.BoolFlag{
-		Name:  "load-unfinalized-blocks-at-startup",
-		Usage: "Enables loading the unfinalized blocks during the beacon chain head initialization",
+	startFromFinalizedCheckpoint = &cli.BoolFlag{
+		Name:  "start-from-finalized-checkpoint",
+		Usage: "Informs the blockchain service to set the head to the finalized checkpoint at startup",
 	}
 )
 
@@ -231,7 +231,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	disableResourceManager,
 	DisableRegistrationCache,
 	disableAggregateParallel,
-	loadUnfinalizedBlocksAtStartup,
+	startFromFinalizedCheckpoint,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -169,9 +169,18 @@ var (
 		Usage: "Disables parallel aggregation of attestations",
 	}
 
-	startFromFinalizedCheckpoint = &cli.BoolFlag{
-		Name:  "start-from-finalized-checkpoint",
-		Usage: "Informs the blockchain service to set the head to the finalized checkpoint at startup",
+	enableCrashRecovery = &cli.BoolFlag{
+		Name:   "enable-crash-recovery",
+		Usage:  "Enables the crash recovery procedures",
+		Value:  false,
+		Hidden: true,
+	}
+
+	enableStartupUnfinalized = &cli.BoolFlag{
+		Name:   "startup-unfinalized",
+		Usage:  "Enables the unfinalized block processing at startup",
+		Value:  false,
+		Hidden: true,
 	}
 )
 
@@ -231,7 +240,8 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	disableResourceManager,
 	DisableRegistrationCache,
 	disableAggregateParallel,
-	startFromFinalizedCheckpoint,
+	enableStartupUnfinalized,
+	enableCrashRecovery,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.

--- a/config/features/flags.go
+++ b/config/features/flags.go
@@ -168,6 +168,11 @@ var (
 		Name:  "disable-aggregate-parallel",
 		Usage: "Disables parallel aggregation of attestations",
 	}
+
+	loadUnfinalizedBlocksAtStartup = &cli.BoolFlag{
+		Name:  "load-unfinalized-blocks-at-startup",
+		Usage: "Enables loading the unfinalized blocks during the beacon chain head initialization",
+	}
 )
 
 // devModeFlags holds list of flags that are set when development mode is on.
@@ -226,6 +231,7 @@ var BeaconChainFlags = append(deprecatedBeaconFlags, append(deprecatedFlags, []c
 	disableResourceManager,
 	DisableRegistrationCache,
 	disableAggregateParallel,
+	loadUnfinalizedBlocksAtStartup,
 }...)...)
 
 // E2EBeaconChainFlags contains a list of the beacon chain feature flags to be tested in E2E.

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -340,6 +340,11 @@ func (node *BeaconNode) Resume() error {
 	return node.cmd.Process.Signal(syscall.SIGCONT)
 }
 
+// GracefulShutdown shuts down the component safely.
+func (node *BeaconNode) GracefulShutdown() error {
+	return node.cmd.Process.Signal(syscall.SIGINT)
+}
+
 // Stop stops the component and its underlying process.
 func (node *BeaconNode) Stop() error {
 	return node.cmd.Process.Kill()

--- a/testing/endtoend/components/beacon_node.go
+++ b/testing/endtoend/components/beacon_node.go
@@ -10,6 +10,7 @@ import (
 	"path"
 	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
@@ -39,6 +40,7 @@ type BeaconNodeSet struct {
 	nodes   []e2etypes.ComponentRunner
 	enr     string
 	ids     []string
+	once    sync.Once
 	started chan struct{}
 }
 
@@ -77,8 +79,12 @@ func (s *BeaconNodeSet) Start(ctx context.Context) error {
 			}
 			s.config.PeerIDs = s.ids
 		}
-		// All nodes started, close channel, so that all services waiting on a set, can proceed.
-		close(s.started)
+
+		// @NOTE(rgeraldes): workaround to be able to restart the set (close panics on restart)
+		s.once.Do(func() {
+			// All nodes started, close channel, so that all services waiting on a set, can proceed.
+			close(s.started)
+		})
 	})
 }
 
@@ -101,6 +107,16 @@ func (s *BeaconNodeSet) Pause() error {
 func (s *BeaconNodeSet) Resume() error {
 	for _, n := range s.nodes {
 		if err := n.Resume(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GracefulShutdown shuts down the component safely.
+func (s *BeaconNodeSet) GracefulShutdown() error {
+	for _, n := range s.nodes {
+		if err := n.GracefulShutdown(); err != nil {
 			return err
 		}
 	}
@@ -270,7 +286,7 @@ func (node *BeaconNode) Start(ctx context.Context) error {
 		fmt.Sprintf("--%s=%s", cmdshared.ChainConfigFileFlag.Name, cfgPath),
 		"--" + cmdshared.ValidatorMonitorIndicesFlag.Name + "=1",
 		"--" + cmdshared.ValidatorMonitorIndicesFlag.Name + "=2",
-		"--" + cmdshared.ForceClearDB.Name,
+		//"--" + cmdshared.ForceClearDB.Name, @NOTE(rgeraldes): we cannot use this one if we're going for restarts
 		"--" + cmdshared.AcceptTosFlag.Name,
 		"--" + flags.EnableDebugRPCEndpoints.Name,
 	}

--- a/testing/endtoend/components/boot_node.go
+++ b/testing/endtoend/components/boot_node.go
@@ -92,6 +92,12 @@ func (node *BootNode) Resume() error {
 	return node.cmd.Process.Signal(syscall.SIGCONT)
 }
 
+// GracefulShutdown shuts down the component safely.
+func (node *BootNode) GracefulShutdown() error {
+	// no-op
+	return nil
+}
+
 // Stop stops the component and its underlying process.
 func (node *BootNode) Stop() error {
 	return node.cmd.Process.Kill()

--- a/testing/endtoend/components/builder.go
+++ b/testing/endtoend/components/builder.go
@@ -74,6 +74,12 @@ func (s *BuilderSet) Resume() error {
 	return nil
 }
 
+// GracefulShutdown shuts down the component safely.
+func (s *BuilderSet) GracefulShutdown() error {
+	// no-op
+	return nil
+}
+
 // Stop stops the component and its underlying process.
 func (s *BuilderSet) Stop() error {
 	for _, n := range s.builders {

--- a/testing/endtoend/components/lighthouse_beacon.go
+++ b/testing/endtoend/components/lighthouse_beacon.go
@@ -93,6 +93,12 @@ func (s *LighthouseBeaconNodeSet) Resume() error {
 	return nil
 }
 
+// GracefulShutdown shuts down the component safely.
+func (s *LighthouseBeaconNodeSet) GracefulShutdown() error {
+	// no-op
+	return nil
+}
+
 // Stop stops the component and its underlying process.
 func (s *LighthouseBeaconNodeSet) Stop() error {
 	for _, n := range s.nodes {

--- a/testing/endtoend/components/lighthouse_validator.go
+++ b/testing/endtoend/components/lighthouse_validator.go
@@ -286,6 +286,12 @@ func (k *KeystoreGenerator) Resume() error {
 	return nil
 }
 
+// GracefulShutdown shuts down the component safely.
+func (node *KeystoreGenerator) GracefulShutdown() error {
+	// no-op
+	return nil
+}
+
 // Stop stops the component and its underlying process.
 func (k *KeystoreGenerator) Stop() error {
 	// no-op

--- a/testing/endtoend/components/tracing_sink.go
+++ b/testing/endtoend/components/tracing_sink.go
@@ -71,6 +71,11 @@ func (ts *TracingSink) Resume() error {
 	return nil
 }
 
+// GracefulShutdown shuts down the component safely.
+func (ts *TracingSink) GracefulShutdown() error {
+	return nil
+}
+
 // Stop stops the component and its underlying process.
 func (ts *TracingSink) Stop() error {
 	ts.cancel()

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -325,6 +325,11 @@ func (v *ValidatorNode) Resume() error {
 	return v.cmd.Process.Signal(syscall.SIGCONT)
 }
 
+// GracefulShutdown shuts down the component safely.
+func (v *ValidatorNode) GracefulShutdown() error {
+	return v.cmd.Process.Signal(syscall.SIGTERM)
+}
+
 // Stop stops the component and its underlying process.
 func (v *ValidatorNode) Stop() error {
 	return v.cmd.Process.Kill()

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -344,7 +344,7 @@ func (v *ValidatorNode) Resume() error {
 
 // GracefulShutdown shuts down the component safely.
 func (v *ValidatorNode) GracefulShutdown() error {
-	return v.cmd.Process.Signal(syscall.SIGTERM)
+	return v.cmd.Process.Signal(syscall.SIGINT)
 }
 
 // Stop stops the component and its underlying process.

--- a/testing/endtoend/components/validator.go
+++ b/testing/endtoend/components/validator.go
@@ -9,6 +9,7 @@ import (
 	"path"
 	"path/filepath"
 	"strings"
+	"sync"
 	"syscall"
 
 	"github.com/bazelbuild/rules_go/go/tools/bazel"
@@ -37,9 +38,11 @@ var _ e2etypes.MultipleComponentRunners = (*ValidatorNodeSet)(nil)
 // ValidatorNodeSet represents set of validator nodes.
 type ValidatorNodeSet struct {
 	e2etypes.ComponentRunner
-	config  *e2etypes.E2EConfig
+	config *e2etypes.E2EConfig
+	nodes  []e2etypes.ComponentRunner
+
+	once    sync.Once
 	started chan struct{}
-	nodes   []e2etypes.ComponentRunner
 }
 
 // NewValidatorNodeSet creates and returns a set of validator nodes.
@@ -70,8 +73,12 @@ func (s *ValidatorNodeSet) Start(ctx context.Context) error {
 	// Wait for all nodes to finish their job (blocking).
 	// Once nodes are ready passed in handler function will be called.
 	return helpers.WaitOnNodes(ctx, nodes, func() {
-		// All nodes started, close channel, so that all services waiting on a set, can proceed.
-		close(s.started)
+		// @NOTE(rgeraldes): workaround to be able to restart the set (close panics on restart)
+		s.once.Do(func() {
+			// All nodes started, close channel, so that all services waiting on a set, can proceed.
+			close(s.started)
+		})
+
 	})
 }
 
@@ -94,6 +101,16 @@ func (s *ValidatorNodeSet) Pause() error {
 func (s *ValidatorNodeSet) Resume() error {
 	for _, n := range s.nodes {
 		if err := n.Resume(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// GracefulShutdown shuts down the component safely.
+func (s *ValidatorNodeSet) GracefulShutdown() error {
+	for _, n := range s.nodes {
+		if err := n.GracefulShutdown(); err != nil {
 			return err
 		}
 	}
@@ -233,7 +250,7 @@ func (v *ValidatorNode) Start(ctx context.Context) error {
 		fmt.Sprintf("--%s=%s", cmdshared.VerbosityFlag.Name, "debug"),
 		fmt.Sprintf("--%s=%s", flags.ProposerSettingsFlag.Name, proposerSettingsPathPath),
 		fmt.Sprintf("--%s=%s", cmdshared.ChainConfigFileFlag.Name, cfgPath),
-		"--" + cmdshared.ForceClearDB.Name,
+		//"--" + cmdshared.ForceClearDB.Name, @NOTE(rgeraldes): we cannot use this one if we're going for restarts
 		"--" + cmdshared.AcceptTosFlag.Name,
 	}
 

--- a/testing/endtoend/components/web3remotesigner.go
+++ b/testing/endtoend/components/web3remotesigner.go
@@ -133,6 +133,12 @@ func (w *Web3RemoteSigner) Resume() error {
 	return w.cmd.Process.Signal(syscall.SIGCONT)
 }
 
+// GracefulShutdown shuts down the component safely.
+func (w *Web3RemoteSigner) GracefulShutdown() error {
+	// no-op
+	return nil
+}
+
 // Stop stops the component and its underlying process.
 func (w *Web3RemoteSigner) Stop() error {
 	return w.cmd.Process.Kill()

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -765,23 +765,23 @@ func (r *testRunner) multiScenario(ec *e2etypes.EvaluationContext, epoch uint64,
 
 func (r *testRunner) allNodesOffline(ec *e2etypes.EvaluationContext, epoch uint64, conns []*grpc.ClientConn) bool {
 	switch epoch {
+	case 5:
+		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
+		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
+		return true
+	case 6:
+		require.NoError(r.t, r.comHandler.beaconNodes.Resume())
+		require.NoError(r.t, r.comHandler.validatorNodes.Resume())
+		return true
+	case 10:
+		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
+		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
+		return true
 	case 11:
-		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
-		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
-		return true
-	case 12:
 		require.NoError(r.t, r.comHandler.beaconNodes.Resume())
 		require.NoError(r.t, r.comHandler.validatorNodes.Resume())
 		return true
-	case 16:
-		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
-		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
-		return true
-	case 17:
-		require.NoError(r.t, r.comHandler.beaconNodes.Resume())
-		require.NoError(r.t, r.comHandler.validatorNodes.Resume())
-		return true
-	case 13, 14, 18, 19:
+	case 7, 8, 12, 13:
 		return true
 	}
 	return false

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -766,20 +766,20 @@ func (r *testRunner) multiScenario(ec *e2etypes.EvaluationContext, epoch uint64,
 func (r *testRunner) allNodesOffline(ec *e2etypes.EvaluationContext, epoch uint64, conns []*grpc.ClientConn) bool {
 	switch epoch {
 	case 5:
-		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
-		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
+		require.NoError(r.t, r.comHandler.beaconNodes.Stop())
+		require.NoError(r.t, r.comHandler.validatorNodes.Stop())
 		return true
 	case 6:
-		require.NoError(r.t, r.comHandler.beaconNodes.Resume())
-		require.NoError(r.t, r.comHandler.validatorNodes.Resume())
+		require.NoError(r.t, r.comHandler.beaconNodes.Start(r.comHandler.ctx))
+		require.NoError(r.t, r.comHandler.validatorNodes.Start(r.comHandler.ctx))
 		return true
 	case 10:
-		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
-		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
+		require.NoError(r.t, r.comHandler.beaconNodes.Stop())
+		require.NoError(r.t, r.comHandler.validatorNodes.Stop())
 		return true
 	case 11:
-		require.NoError(r.t, r.comHandler.beaconNodes.Resume())
-		require.NoError(r.t, r.comHandler.validatorNodes.Resume())
+		require.NoError(r.t, r.comHandler.beaconNodes.Start(r.comHandler.ctx))
+		require.NoError(r.t, r.comHandler.validatorNodes.Start(r.comHandler.ctx))
 		return true
 	case 7, 8, 12, 13:
 		return true

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -763,6 +763,30 @@ func (r *testRunner) multiScenario(ec *e2etypes.EvaluationContext, epoch uint64,
 	return false
 }
 
+func (r *testRunner) allNodesOffline(ec *e2etypes.EvaluationContext, epoch uint64, conns []*grpc.ClientConn) bool {
+	switch epoch {
+	case 11:
+		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
+		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
+		return true
+	case 12:
+		require.NoError(r.t, r.comHandler.beaconNodes.Resume())
+		require.NoError(r.t, r.comHandler.validatorNodes.Resume())
+		return true
+	case 16:
+		require.NoError(r.t, r.comHandler.beaconNodes.Pause())
+		require.NoError(r.t, r.comHandler.validatorNodes.Pause())
+		return true
+	case 17:
+		require.NoError(r.t, r.comHandler.beaconNodes.Resume())
+		require.NoError(r.t, r.comHandler.validatorNodes.Resume())
+		return true
+	case 13, 14, 18, 19:
+		return true
+	}
+	return false
+}
+
 // All Epochs are valid.
 func defaultInterceptor(_ *e2etypes.EvaluationContext, _ uint64, _ []*grpc.ClientConn) bool {
 	return false

--- a/testing/endtoend/endtoend_test.go
+++ b/testing/endtoend/endtoend_test.go
@@ -787,11 +787,15 @@ func (r *testRunner) allNodesOffline(ec *e2etypes.EvaluationContext, epoch uint6
 			return nil
 		})
 
+		time.Sleep(5 * time.Second)
+
 		// create new connections to the beacon nodes (evaluators)
 		conns, closeConns, err := helpers.NewLocalConnections(r.comHandler.ctx, e2e.TestParams.BeaconNodeCount)
 		require.NoError(r.t, err, "Cannot create local connections")
 		r.beaconConns = conns
 		r.closeBeaconConns = closeConns
+
+		time.Sleep(5 * time.Second)
 
 		r.comHandler.group.Go(func() error {
 			if err := r.comHandler.validatorNodes.Start(r.comHandler.ctx); err != nil {

--- a/testing/endtoend/evaluators/BUILD.bazel
+++ b/testing/endtoend/evaluators/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//beacon-chain/core/helpers:go_default_library",
         "//beacon-chain/core/signing:go_default_library",
         "//beacon-chain/p2p:go_default_library",
+        "//beacon-chain/rpc/eth/beacon:go_default_library",
         "//beacon-chain/state:go_default_library",
         "//config/fieldparams:go_default_library",
         "//config/params:go_default_library",

--- a/testing/endtoend/evaluators/finality.go
+++ b/testing/endtoend/evaluators/finality.go
@@ -2,13 +2,20 @@ package evaluators
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
+	"net/http"
+	"strconv"
+	"time"
 
 	"github.com/pkg/errors"
+	"github.com/prysmaticlabs/prysm/v4/beacon-chain/rpc/eth/beacon"
 	"github.com/prysmaticlabs/prysm/v4/consensus-types/primitives"
 	eth "github.com/prysmaticlabs/prysm/v4/proto/prysm/v1alpha1"
+	"github.com/prysmaticlabs/prysm/v4/testing/endtoend/params"
 	"github.com/prysmaticlabs/prysm/v4/testing/endtoend/policies"
 	"github.com/prysmaticlabs/prysm/v4/testing/endtoend/types"
+	"github.com/prysmaticlabs/prysm/v4/time/slots"
 	"google.golang.org/grpc"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -21,6 +28,85 @@ var FinalizationOccurs = func(epoch primitives.Epoch) types.Evaluator {
 		Policy:     policies.AfterNthEpoch(epoch),
 		Evaluation: finalizationOccurs,
 	}
+}
+
+// NewFinalizedCheckpointOccurs is an evaluator to make sure that the chain keeps reaching finality.
+// Requires to be run after at least 4 epochs have passed.
+var NewFinalizedCheckpointOccurs = func(epoch primitives.Epoch) types.Evaluator {
+	return types.Evaluator{
+		Name:       "new_finalized_checkpoint_at_epoch_%d",
+		Policy:     policies.AfterNthEpoch(epoch),
+		Evaluation: newFinalizedCheckpointOccurs,
+	}
+}
+
+func doMiddlewareJSONGetRequest(template string, requestPath string, beaconNodeIdx int, dst interface{}, bnType ...string) error {
+	var port int
+	if len(bnType) > 0 {
+		switch bnType[0] {
+		case "lighthouse":
+			port = params.TestParams.Ports.LighthouseBeaconNodeHTTPPort
+		default:
+			port = params.TestParams.Ports.PrysmBeaconNodeGatewayPort
+		}
+	} else {
+		port = params.TestParams.Ports.PrysmBeaconNodeGatewayPort
+	}
+
+	basePath := fmt.Sprintf(template, port+beaconNodeIdx)
+	httpResp, err := http.Get(
+		basePath + requestPath,
+	)
+	if err != nil {
+		return err
+	}
+	if httpResp.StatusCode != http.StatusOK {
+		var body interface{}
+		if err := json.NewDecoder(httpResp.Body).Decode(&body); err != nil {
+			return err
+		}
+		return fmt.Errorf("request failed with response code: %d with response body %s", httpResp.StatusCode, body)
+	}
+	return json.NewDecoder(httpResp.Body).Decode(&dst)
+}
+
+func newFinalizedCheckpointOccurs(_ *types.EvaluationContext, conns ...*grpc.ClientConn) error {
+	conn := conns[0]
+	client := eth.NewBeaconChainClient(conn)
+	chainHead, err := client.GetChainHead(context.Background(), &emptypb.Empty{})
+	if err != nil {
+		return errors.Wrap(err, "failed to get chain head")
+	}
+
+	beaconNodeIdx := 0
+	genesisResp := &beacon.GetGenesisResponse{}
+	err = doMiddlewareJSONGetRequest(
+		v1MiddlewarePathTemplate,
+		"/beacon/genesis",
+		beaconNodeIdx,
+		genesisResp,
+	)
+	if err != nil {
+		return errors.Wrap(err, "error getting genesis data")
+	}
+	genesisTime, err := strconv.ParseInt(genesisResp.Data.GenesisTime, 10, 64)
+	if err != nil {
+		return errors.Wrap(err, "could not parse genesis time")
+	}
+
+	currentEpoch := slots.EpochsSinceGenesis(time.Unix(genesisTime, 0))
+	finalizedEpoch := chainHead.FinalizedEpoch
+
+	expectedFinalizedEpoch := currentEpoch - 2
+	if expectedFinalizedEpoch != finalizedEpoch {
+		return fmt.Errorf(
+			"expected finalized epoch to be %d, received: %d",
+			expectedFinalizedEpoch,
+			finalizedEpoch,
+		)
+	}
+
+	return nil
 }
 
 func finalizationOccurs(_ *types.EvaluationContext, conns ...*grpc.ClientConn) error {

--- a/testing/endtoend/minimal_scenario_e2e_test.go
+++ b/testing/endtoend/minimal_scenario_e2e_test.go
@@ -35,13 +35,12 @@ func TestEndToEnd_ScenarioRun_EEOffline(t *testing.T) {
 }
 
 func TestEndToEnd_ScenarioRun_AllNodesGoOffline(t *testing.T) {
-	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(15))
-	// @NOTE(rgeraldes): BeaconNodeCount > 2 has some peer connection issues atm
-	params.TestParams.BeaconNodeCount = 2
+	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(10))
+	params.TestParams.BeaconNodeCount = 4
 
 	evals := scenarioEvals()
 	evals = append(evals, ev.NewFinalizedCheckpointOccurs(3))
-	runner.config.BeaconFlags = append(runner.config.BeaconFlags, "--min-sync-peers=1")
+	runner.config.BeaconFlags = append(runner.config.BeaconFlags, "--min-sync-peers=1", "--enable-crash-recovery")
 	runner.config.Evaluators = evals
 	runner.config.EvalInterceptor = runner.allNodesOffline
 
@@ -54,7 +53,7 @@ func TestEndToEnd_ScenarioRun_SingleNode_NodeGoesOffline(t *testing.T) {
 
 	evals := scenarioEvals()
 	evals = append(evals, ev.NewFinalizedCheckpointOccurs(3))
-	runner.config.BeaconFlags = append(runner.config.BeaconFlags, "--min-sync-peers=0")
+	runner.config.BeaconFlags = append(runner.config.BeaconFlags, "--min-sync-peers=0", "--startup-unfinalized")
 	runner.config.Evaluators = evals
 	runner.config.EvalInterceptor = runner.allNodesOffline
 

--- a/testing/endtoend/minimal_scenario_e2e_test.go
+++ b/testing/endtoend/minimal_scenario_e2e_test.go
@@ -31,3 +31,11 @@ func TestEndToEnd_ScenarioRun_EEOffline(t *testing.T) {
 	runner.config.EvalInterceptor = runner.eeOffline
 	runner.scenarioRunner()
 }
+
+func TestEndToEnd_ScenarioRun_AllNodesOffline(t *testing.T) {
+	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(20))
+
+	runner.config.Evaluators = scenarioEvals()
+	runner.config.EvalInterceptor = runner.allNodesOffline
+	runner.scenarioRunner()
+}

--- a/testing/endtoend/minimal_scenario_e2e_test.go
+++ b/testing/endtoend/minimal_scenario_e2e_test.go
@@ -33,7 +33,7 @@ func TestEndToEnd_ScenarioRun_EEOffline(t *testing.T) {
 }
 
 func TestEndToEnd_ScenarioRun_AllNodesOffline(t *testing.T) {
-	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(20))
+	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(15))
 
 	runner.config.Evaluators = scenarioEvals()
 	runner.config.EvalInterceptor = runner.allNodesOffline

--- a/testing/endtoend/minimal_scenario_e2e_test.go
+++ b/testing/endtoend/minimal_scenario_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/prysmaticlabs/prysm/v4/runtime/version"
+	"github.com/prysmaticlabs/prysm/v4/testing/endtoend/params"
 	"github.com/prysmaticlabs/prysm/v4/testing/endtoend/types"
 )
 
@@ -35,6 +36,15 @@ func TestEndToEnd_ScenarioRun_EEOffline(t *testing.T) {
 func TestEndToEnd_ScenarioRun_AllNodesOffline(t *testing.T) {
 	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(15))
 
+	runner.config.Evaluators = scenarioEvals()
+	runner.config.EvalInterceptor = runner.allNodesOffline
+	runner.scenarioRunner()
+}
+
+func TestEndToEnd_ScenarioRun_AllNodesOffline_SingleNode(t *testing.T) {
+	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(15))
+	runner.config.BeaconFlags = append(runner.config.BeaconFlags, "--min-sync-peers=0")
+	params.TestParams.BeaconNodeCount = 1
 	runner.config.Evaluators = scenarioEvals()
 	runner.config.EvalInterceptor = runner.allNodesOffline
 	runner.scenarioRunner()

--- a/testing/endtoend/minimal_scenario_e2e_test.go
+++ b/testing/endtoend/minimal_scenario_e2e_test.go
@@ -42,7 +42,7 @@ func TestEndToEnd_ScenarioRun_AllNodesOffline(t *testing.T) {
 }
 
 func TestEndToEnd_ScenarioRun_AllNodesOffline_SingleNode(t *testing.T) {
-	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(15))
+	runner := e2eMinimal(t, version.Phase0, types.WithEpochs(10))
 
 	params.TestParams.BeaconNodeCount = 1
 

--- a/testing/endtoend/types/empty.go
+++ b/testing/endtoend/types/empty.go
@@ -39,6 +39,10 @@ func (*EmptyComponent) Resume() error {
 	return nil
 }
 
+func (*EmptyComponent) GracefulShutdown() error {
+	return nil
+}
+
 func (*EmptyComponent) Stop() error {
 	return nil
 }

--- a/testing/endtoend/types/types.go
+++ b/testing/endtoend/types/types.go
@@ -142,6 +142,8 @@ type ComponentRunner interface {
 	Pause() error
 	// Resume resumes a component.
 	Resume() error
+	// GracefulShutdown shuts down a component safely.
+	GracefulShutdown() error
 	// Stop stops a component.
 	Stop() error
 	// UnderlyingProcess is the underlying process, once started.


### PR DESCRIPTION
More context [here](https://github.com/rgeraldes24/eth-pos-devnet/blob/main/tasks/3.md). 

This PR solves two problems:
- In a single node setup, the validator cannot resume his duties because the beacon node does not load the latest head upon a restart. By using the '--startup-unfinalized' hidden flag for this setup, the validator can resume his duties.
- In a network-wide crash, the nodes look for head slots - from the connected peers - greater than the one they all have(finalized checkpoint) during the initial sync upon a restart. Those slots are not known by anyone and they all get stuck, so we load the unfinalized head in this PR to overcome that issue. Additionally, during the initial sync, they look for the expected slot since genesis time which is not going to happen, given that all the nodes will be stuck in the initial sync. Instead of going for the expected slot, we pick the best known slot from the connected peers (min sync peers * 2) for this scenario. By using the new '--enable-crash-recovery' hidden flag we enable the crash recovery procedures - unfinalized head start and configure sync to use the best known slot.

E2E tests are available for both scenarios:

Network wide crash 
```
bazel test //testing/endtoend:go_minimal_scenario_test --//proto:network=minimal --test_filter=TestEndToEnd_ScenarioRun_AllNodesGoOffline --test_env=E2E_EPOCHS=10 --test_timeout=1000 --test_output=streamed
```

Single node restart

```
bazel test //testing/endtoend:go_minimal_scenario_test --//proto:network=minimal --test_filter=TestEndToEnd_ScenarioRun_SingleNode_NodeGoesOffline --test_env=E2E_EPOCHS=10 --test_timeout=1000 --test_output=streamed
```
